### PR TITLE
chore(Healthcheck): change backend healthcheck url

### DIFF
--- a/terraform/backend-instance-group.tf
+++ b/terraform/backend-instance-group.tf
@@ -6,7 +6,7 @@ resource "google_compute_health_check" "backend-health-check" {
   unhealthy_threshold = 10                                                      # 50 seconds
 
   http_health_check {
-    request_path = "/mrm?query=query%7B%0A%20allLocations%20%7B%0A%20%20%20id%0A%20%7D%0A%7D"
+    request_path = "/_healthcheck?query=%7B%0A%20%20rooms%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D"
     port         = "8000"
   }
 }
@@ -64,7 +64,7 @@ module "gce_lb_http_be" {
   }
 
   backend_params = [
-    "/mrm?query=query%7B%0A%20allLocations%20%7B%0A%20%20%20id%0A%20%7D%0A%7D,http,8000,15",
+    "/_healthcheck?query=%7B%0A%20%20rooms%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D,http,8000,15",
   ]
 
   private_key = "${file("../secrets/star_andela_key.pem")}"


### PR DESCRIPTION
#### What does this PR do?
- Replace the backend health check url on mrm-api infrastructure
#### Description of Task to be completed?
- [x] Replace the backend health check url on mrm-api infrastructure
#### How should this be manually tested?
- Restart the `mrm-backend-instance-group` on `Andela-learning` service account
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
- story type - chore
- story title - Replace the current health_check url on mrm_api infrastructure
- story id - #158830040

### Screenshot
>- testing downtime and uptime on sandbox environment
<img width="694" alt="screen shot 2018-07-09 at 11 20 27 am" src="https://user-images.githubusercontent.com/22421283/42445168-2ed977bc-836a-11e8-9977-316ffae0bfc5.png">
