### PR TITLE
#160918977 modify template source images

### DIFF
--- a/terraform/instance-group-template.tf
+++ b/terraform/instance-group-template.tf
@@ -7,7 +7,7 @@ resource "google_compute_instance_template" "frontend-template" {
 
   disk {
     boot         = "true"
-    source_image = "mrm-frontend-packer-image"
+    source_image = "{var.frontend_image_url}"
   }
 
   metadata {
@@ -43,7 +43,7 @@ resource "google_compute_instance_template" "backend-template" {
 
   disk {
     boot         = "true"
-    source_image = "mrm-backend-packer-image"
+    source_image = "{var.backend_image_url}"
   }
 
   metadata {


### PR DESCRIPTION
#### What does this PR do?

- [x] Uses image url for templates' source image

#### Any background context you want to provide?

- [x] With the change to terraform [google provider](https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md#1180-september-17-2018) , an instance template can only pick the image only when given the [full path](https://github.com/terraform-providers/terraform-provider-google/pull/1916)

#### What are the relevant pivotal tracker stories?
[160918977](https://www.pivotaltracker.com/story/show/160918977)
