### PR TITLE
#160941616 fix backend migrations

### DIFF
--- a/images/backend-image/startup-script.sh.templ
+++ b/images/backend-image/startup-script.sh.templ
@@ -129,7 +129,7 @@ function setup_env_variables {
   fi
 }
 function run_migration {
-  export $(cat .env)
+  export $(cat /home/packer/mrm_api/.env | xargs)
   export DATABASE_URL="$(database_url)"
   export DEV_DATABASE_URL="$(database_url)"
   export SECRET_KEY="$(retrieve_secret_key)"

--- a/terraform/instance-group-template.tf
+++ b/terraform/instance-group-template.tf
@@ -7,7 +7,7 @@ resource "google_compute_instance_template" "frontend-template" {
 
   disk {
     boot         = "true"
-    source_image = "mrm-frontend-packer-image"
+    source_image = "{var.frontend_image_url}"
   }
 
   metadata {
@@ -43,7 +43,7 @@ resource "google_compute_instance_template" "backend-template" {
 
   disk {
     boot         = "true"
-    source_image = "mrm-backend-packer-image"
+    source_image = "{var.backend_image_url}"
   }
 
   metadata {

--- a/terraform/variables.tf.templ
+++ b/terraform/variables.tf.templ
@@ -110,3 +110,10 @@ variable "database_version" {
   type = "string"
 }
 
+variable "frontend_image_url" {
+  type = "string"
+}
+
+variable "backend_image_url" {
+  type = "string"
+}


### PR DESCRIPTION
#### What does this PR do?

- [x] Converts standard input `.env` file for the `cat` command into arguments using `xargs`
- [x] Adds instance template variables for `source_images` to `variables.tf.templ`

What are the relevant pivotal tracker stories?
[160941616](https://www.pivotaltracker.com/story/show/160941616)