### PR TITLE
DA-401: Scale down GCP machine-type

### DIFF
--- a/gke/cluster.tf
+++ b/gke/cluster.tf
@@ -16,5 +16,16 @@ resource "google_container_cluster" "converge_cluster" {
             auto_upgrade        = true
         }
     }]
+    node_config {
+        machine_type = "g1-small"
+        oauth_scopes = [
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring",
+            "https://www.googleapis.com/auth/service.management.readonly",
+            "https://www.googleapis.com/auth/servicecontrol",
+            "https://www.googleapis.com/auth/trace.append",
+            "https://www.googleapis.com/auth/compute"
+        ]
+    }
 }
-


### PR DESCRIPTION
#### What does this PR do?

- [x] Scale down cluster machine type from n1-standard-1 (default) to g1-small

#### How can this be manually tested?
N/A

#### Any background context you want to provide?
This is meant to save costs and maximise resources usage.

#### What are the relevant Jira tracker stories?
[#DA-401](https://andela-apprenticeship.atlassian.net/browse/DA-401)

#### Screenshots (if appropriate):
N/A