### PR TITLE
DA-415: Use n1-standard-1 machine_type

### DIFF
--- a/gke/cluster.tf
+++ b/gke/cluster.tf
@@ -21,10 +21,11 @@ resource "google_container_node_pool" "converge_node_pool" {
 
   management {
     auto_upgrade = true
+    auto_repair  = true
   }
 
   node_config {
-    machine_type = "g1-small"
+    machine_type = "n1-standard-1"
     metadata = {
       disable-legacy-endpoints = "true"
     }

--- a/k8s/backend-autoscaler.tf
+++ b/k8s/backend-autoscaler.tf
@@ -4,7 +4,7 @@ resource "kubernetes_horizontal_pod_autoscaler" "backend" {
     namespace = "${kubernetes_namespace.namespace.id}"
   }
   spec {
-    max_replicas = 4
+    max_replicas = 5
     min_replicas = 2
     target_cpu_utilization_percentage = "80"
     scale_target_ref {


### PR DESCRIPTION
#### What does this PR do?

- [x] Changes the machine_type from g1-small to n1-standard-1

#### How can this be manually tested?
N/A

#### Any background context you want to provide?
- [x] Insufficient Memory and CPU causes *CrashLoopBackOff* on API pods, leading to downtime.

#### What are the relevant pivotal tracker stories?
[ #DA-415](https://andela-apprenticeship.atlassian.net/browse/DA-415)

#### Screenshots (if appropriate):
<img width="1440" alt="Screen Shot 2019-08-29 at 12 28 05" src="https://user-images.githubusercontent.com/25563661/63936768-9bb87280-ca58-11e9-9611-0f782e345206.png">
